### PR TITLE
Improving the compatibility with other libraries and interrupts

### DIFF
--- a/TFT_ILI9341.cpp
+++ b/TFT_ILI9341.cpp
@@ -207,7 +207,6 @@ void TFT_ILI9341::init(void)
   SPI.setDataMode(SPI_MODE0);
   mySPCR = SPCR;
 
-  spi_end();
 
   // toggle RST low to reset
   if (TFT_RST > 0) {

--- a/TFT_ILI9341.cpp
+++ b/TFT_ILI9341.cpp
@@ -169,6 +169,7 @@ static inline void spi_begin(void) {
 static inline void spi_end(void) __attribute__((always_inline));
 
 static inline void spi_end(void) {
+  while (!(SPSR & _BV(SPIF))); // wait for everything SPI to finish before freeing up the bus
   SPI.endTransaction();
 }
   #else // we do not want to SUPPORT_TRANSACTIONS

--- a/TFT_ILI9341.cpp
+++ b/TFT_ILI9341.cpp
@@ -949,7 +949,6 @@ void TFT_ILI9341::setWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 
 void TFT_ILI9341::setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 {
-  //spi_begin(); not needed because all functions calling setAddrWindow already executed this command
 
   // Column addr set
   TFT_DC_C;
@@ -991,7 +990,6 @@ void TFT_ILI9341::setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
   //TFT_CS_H;
   TFT_DC_D;
 
-  //spi_end(); not needed because all functions calling setAddrWindow will execute this command afterwards
 }
 
 /*

--- a/TFT_ILI9341.cpp
+++ b/TFT_ILI9341.cpp
@@ -950,7 +950,7 @@ void TFT_ILI9341::setWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 
 void TFT_ILI9341::setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 {
-  spi_begin();
+  //spi_begin(); not needed because all functions calling setAddrWindow already executed this command
 
   // Column addr set
   TFT_DC_C;
@@ -992,7 +992,7 @@ void TFT_ILI9341::setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
   //TFT_CS_H;
   TFT_DC_D;
 
-  spi_end();
+  //spi_end(); not needed because all functions calling setAddrWindow will execute this command afterwards
 }
 
 /*


### PR DESCRIPTION
These changes are needed to use this library with this one https://github.com/PaulStoffregen/XPT2046_Touchscreen and the official SD library on the same SPI bus and to not disable Interrupts when calling e.g. fillRect. Please see the commit description for more details as to why I made these changes.
I'm not too familiar with Github and I'm not entirely sure why both commits went in one pull request but I thought these updates might help someone else trying to use a fast ILI9341 library without these problems.  I also have no idea why github thinks the last line changed, I used the online editor to change the files. 
Please tell me if I could have done anything better.